### PR TITLE
Autodeploy (Part 1)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,3 +27,6 @@ Style/Lambda:
 
 Style/Send:
   Enabled: true
+
+Style/NumericLiterals:
+  Enabled: false

--- a/app/github/github_event_handler.rb
+++ b/app/github/github_event_handler.rb
@@ -1,0 +1,35 @@
+# GithubEventHandler is a base GitHub event handler. All GitHub event handler
+# should inherit from this.
+class GithubEventHandler
+  attr_reader :slashdeploy
+
+  UnknownRepository = Class.new(SlashDeploy::Error)
+
+  def initialize(slashdeploy)
+    @slashdeploy = slashdeploy
+  end
+
+  def call(env)
+    env['rack.input'] = StringIO.new env['rack.input'].read
+    req = ::Rack::Request.new env
+    event = JSON.parse req.body.read
+    req.body.rewind # rewind body so downstream can re-read.
+
+    repo_name = event['repository']['full_name']
+    repo = Repository.find_by(name: repo_name)
+    fail(UnknownRepository, "Received GitHub webhook for unknown repository: #{repo_name}") unless repo
+    return [403, {}, ['']] unless Hookshot.verify(req, repo.github_secret)
+
+    run(repo, event)
+
+    [200, {}, ['']]
+  end
+
+  def run(_repository, _event)
+    fail NotImplementedError
+  end
+
+  private
+
+  delegate :transaction, to: :'ActiveRecord::Base'
+end

--- a/app/github/github_event_handler.rb
+++ b/app/github/github_event_handler.rb
@@ -1,35 +1,44 @@
 # GithubEventHandler is a base GitHub event handler. All GitHub event handler
 # should inherit from this.
 class GithubEventHandler
+  attr_reader :env
   attr_reader :slashdeploy
 
   UnknownRepository = Class.new(SlashDeploy::Error)
 
-  def initialize(slashdeploy)
+  def self.call(env)
+    new(env, ::SlashDeploy.service).call
+  end
+
+  def initialize(env, slashdeploy)
+    @env = env
     @slashdeploy = slashdeploy
   end
 
-  def call(env)
+  def call
     env['rack.input'] = StringIO.new env['rack.input'].read
     req = ::Rack::Request.new env
-    event = JSON.parse req.body.read
+    @event = JSON.parse req.body.read
     req.body.rewind # rewind body so downstream can re-read.
 
-    repo_name = event['repository']['full_name']
-    repo = Repository.find_by(name: repo_name)
-    fail(UnknownRepository, "Received GitHub webhook for unknown repository: #{repo_name}") unless repo
-    return [403, {}, ['']] unless Hookshot.verify(req, repo.github_secret)
+    repo_name = @event['repository']['full_name']
+    @repository = Repository.find_by(name: repo_name)
+    fail(UnknownRepository, "Received GitHub webhook for unknown repository: #{repo_name}") unless @repository
+    return [403, {}, ['']] unless Hookshot.verify(req, @repository.github_secret)
 
-    run(repo, event)
+    run
 
     [200, {}, ['']]
   end
 
-  def run(_repository, _event)
+  def run
     fail NotImplementedError
   end
 
   private
+
+  attr_reader :repository
+  attr_reader :event
 
   delegate :transaction, to: :'ActiveRecord::Base'
 end

--- a/app/github/push_event.rb
+++ b/app/github/push_event.rb
@@ -1,0 +1,12 @@
+# Handles the push event from github.
+class PushEvent < GithubEventHandler
+  def run(repository, event)
+    branch = event['ref'].gsub('refs/heads/', '')
+
+    transaction do
+      environment = repository.auto_deploy_environment_for_branch(branch)
+      return unless environment
+      slashdeploy.create_deployment environment.auto_deploy_user, environment, event['head']
+    end
+  end
+end

--- a/app/github/push_event.rb
+++ b/app/github/push_event.rb
@@ -6,7 +6,16 @@ class PushEvent < GithubEventHandler
     transaction do
       environment = repository.auto_deploy_environment_for_branch(branch)
       return unless environment
-      slashdeploy.create_deployment environment.auto_deploy_user, environment, event['head']
+      user = deployer(event['sender']['id'], environment.auto_deploy_user)
+      slashdeploy.create_deployment user, environment, event['head']
     end
+  end
+
+  private
+
+  def deployer(sender_id, fallback)
+    account = GithubAccount.find_by(id: sender_id)
+    return fallback unless account
+    account.user
   end
 end

--- a/app/github/push_event.rb
+++ b/app/github/push_event.rb
@@ -9,13 +9,8 @@ class PushEvent < GithubEventHandler
 
   private
 
-  def branch
-    # TODO: tags? forks?
-    @branch ||= event['ref'].gsub('refs/heads/', '')
-  end
-
   def environment
-    @environment = repository.auto_deploy_environment_for_branch(branch)
+    @environment = repository.auto_deploy_environment_for_ref(event['ref'])
   end
 
   def deployer

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -44,12 +44,12 @@ class Environment < ActiveRecord::Base
   end
 
   # Configures this environment to auto deploy the given branch.
-  def configure_auto_deploy(branch, options = {})
-    self.update_attributes!(auto_deploy_branch: branch, auto_deploy_user: options[:fallback_user])
+  def configure_auto_deploy(ref, options = {})
+    self.update_attributes!(auto_deploy_ref: ref, auto_deploy_user: options[:fallback_user])
   end
 
-  def auto_deploy?(branch)
-    auto_deploy_branch == branch
+  def auto_deploy?(ref)
+    auto_deploy_ref == ref
   end
 
   # The default git ref to deploy when none is provided for this environment.

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -45,7 +45,7 @@ class Environment < ActiveRecord::Base
 
   # Configures this environment to auto deploy the given branch.
   def configure_auto_deploy(branch, options = {})
-    self.update_attributes!(auto_deploy_branch: branch, auto_deploy_user: options[:user])
+    self.update_attributes!(auto_deploy_branch: branch, auto_deploy_user: options[:fallback_user])
   end
 
   def auto_deploy?(branch)

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -2,6 +2,7 @@
 class Environment < ActiveRecord::Base
   has_many :locks
   belongs_to :repository
+  belongs_to :auto_deploy_user, class_name: :User, foreign_key: :auto_deploy_user_id
 
   # Validate that an alias doesn't match a different environment.
   validates_with UniqueEnvironment
@@ -40,6 +41,15 @@ class Environment < ActiveRecord::Base
   # the environment.
   def aliases=(aliases)
     super((aliases || []).select { |a| a != name })
+  end
+
+  # Configures this environment to auto deploy the given branch.
+  def configure_auto_deploy(branch, options = {})
+    self.update_attributes!(auto_deploy_branch: branch, auto_deploy_user: options[:user])
+  end
+
+  def auto_deploy?(branch)
+    auto_deploy_branch == branch
   end
 
   # The default git ref to deploy when none is provided for this environment.

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -3,6 +3,10 @@ class Repository < ActiveRecord::Base
   has_many :environments
   validates :name, repository: true
 
+  after_initialize do
+    self.github_secret ||= SecureRandom.hex
+  end
+
   # Finds the repository with the given name, creating it if necessary.
   def self.with_name(name)
     find_or_create_by!(name: name)
@@ -17,6 +21,12 @@ class Repository < ActiveRecord::Base
   # The default environment to deploy to when one is not specified.
   def default_environment
     super.presence || self.class.default_environment
+  end
+
+  # Returns the environment that's configured to auto deploy this branch.
+  # Returns nil if there is not environment configured for this branch.
+  def auto_deploy_environment_for_branch(branch)
+    environments.find { |env| env.auto_deploy?(branch) }
   end
 
   # The name of the default environment for a repository.

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -23,10 +23,10 @@ class Repository < ActiveRecord::Base
     super.presence || self.class.default_environment
   end
 
-  # Returns the environment that's configured to auto deploy this branch.
-  # Returns nil if there is not environment configured for this branch.
-  def auto_deploy_environment_for_branch(branch)
-    environments.find { |env| env.auto_deploy?(branch) }
+  # Returns the environment that's configured to auto deploy this ref.
+  # Returns nil if there is no environment configured for this branch.
+  def auto_deploy_environment_for_ref(ref)
+    environments.find { |env| env.auto_deploy?(ref) }
   end
 
   # The name of the default environment for a repository.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   get '/slack/install' => 'slack#install', as: :install
 
   mount SlashDeploy::Commands.slack, at: '/commands'
+  post '/', to: SlashDeploy.github_webhooks, constraints: Hookshot.constraint
 
   root 'pages#index'
   # The priority is based upon order of creation: first created -> highest priority.

--- a/db/migrate/20160209082726_add_github_secret_to_repositories.rb
+++ b/db/migrate/20160209082726_add_github_secret_to_repositories.rb
@@ -1,0 +1,14 @@
+class AddGithubSecretToRepositories < ActiveRecord::Migration
+  def up
+    add_column :repositories, :github_secret, :string
+    Repository.reset_column_information
+    Repository.find_each do |repository|
+      repository.update_attributes!(github_secret: SecureRandom.hex)
+    end
+    change_column :repositories, :github_secret, :string, null: false
+  end
+  
+  def down
+    remove_column :repositories, :github_secret
+  end
+end

--- a/db/migrate/20160209085736_add_auto_deploy_branch_to_environment.rb
+++ b/db/migrate/20160209085736_add_auto_deploy_branch_to_environment.rb
@@ -1,0 +1,6 @@
+class AddAutoDeployBranchToEnvironment < ActiveRecord::Migration
+  def change
+    add_column :environments, :auto_deploy_branch, :string
+    add_column :environments, :auto_deploy_user_id, :integer
+  end
+end

--- a/db/migrate/20160209085736_add_auto_deploy_branch_to_environment.rb
+++ b/db/migrate/20160209085736_add_auto_deploy_branch_to_environment.rb
@@ -1,6 +1,6 @@
 class AddAutoDeployBranchToEnvironment < ActiveRecord::Migration
   def change
-    add_column :environments, :auto_deploy_branch, :string
+    add_column :environments, :auto_deploy_ref, :string
     add_column :environments, :auto_deploy_user_id, :integer
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -41,7 +41,9 @@ CREATE TABLE environments (
     repository_id integer NOT NULL,
     in_channel boolean DEFAULT false NOT NULL,
     aliases text[] DEFAULT '{}'::text[],
-    default_ref character varying
+    default_ref character varying,
+    auto_deploy_branch character varying,
+    auto_deploy_user_id integer
 );
 
 
@@ -119,7 +121,8 @@ CREATE TABLE repositories (
     name character varying NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    default_environment character varying
+    default_environment character varying,
+    github_secret character varying NOT NULL
 );
 
 
@@ -408,6 +411,10 @@ INSERT INTO schema_migrations (version) VALUES ('20160205060045');
 INSERT INTO schema_migrations (version) VALUES ('20160205063654');
 
 INSERT INTO schema_migrations (version) VALUES ('20160209012632');
+
+INSERT INTO schema_migrations (version) VALUES ('20160209082726');
+
+INSERT INTO schema_migrations (version) VALUES ('20160209085736');
 
 INSERT INTO schema_migrations (version) VALUES ('20160210071446');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -42,7 +42,7 @@ CREATE TABLE environments (
     in_channel boolean DEFAULT false NOT NULL,
     aliases text[] DEFAULT '{}'::text[],
     default_ref character varying,
-    auto_deploy_branch character varying,
+    auto_deploy_ref character varying,
     auto_deploy_user_id integer
 );
 

--- a/lib/hookshot.rb
+++ b/lib/hookshot.rb
@@ -1,0 +1,25 @@
+# Hookshot provides helpers for handling GitHub webhooks.
+module Hookshot
+  HEADER_GITHUB_EVENT  = 'HTTP_X_GITHUB_EVENT'.freeze
+  HEADER_HUB_SIGNATURE = 'HTTP_X_HUB_SIGNATURE'.freeze
+
+  autoload :Router, 'hookshot/router'
+
+  # Signature calculates the SHA1 HMAC signature of the request body.
+  def self.signature(body, secret)
+    OpenSSL::HMAC.hexdigest('sha1', secret, body)
+  end
+
+  # Verifies that the request body matches the secret.
+  def self.verify(request, secret)
+    body = request.body.read
+    sig = "sha1=#{signature(body, secret)}"
+    ActiveSupport::SecurityUtils.secure_compare(sig, request.env[HEADER_HUB_SIGNATURE])
+  end
+
+  # Returns a rails router compatible constraint matcher that matches the
+  # X-GitHub-Event header to ensure it's presence.
+  def self.constraint
+    -> (request) { request.env[Hookshot::HEADER_GITHUB_EVENT] }
+  end
+end

--- a/lib/hookshot/router.rb
+++ b/lib/hookshot/router.rb
@@ -1,0 +1,27 @@
+require 'rack'
+
+module Hookshot
+  # Router is a Rack application that demuxes GitHub webhooks to other Rack
+  # applications.
+  #
+  # Example
+  #
+  #   router = Hookshot::Router.new
+  #   router.handle :push, PushHandler.new
+  #   router.handle :deployment, DeploymentHandler.new
+  class Router
+    def apps
+      @apps ||= {}
+    end
+
+    def handle(event, app)
+      apps[event.to_sym] = app
+    end
+
+    def call(env)
+      app = apps[env[HEADER_GITHUB_EVENT].to_sym]
+      return [404, {}, ['']] unless app
+      app.call(env)
+    end
+  end
+end

--- a/lib/slashdeploy.rb
+++ b/lib/slashdeploy.rb
@@ -109,7 +109,7 @@ module SlashDeploy
 
     def github_webhooks
       router = Hookshot::Router.new
-      router.handle :push, PushEvent.new(service)
+      router.handle :push, PushEvent
       router
     end
 

--- a/lib/slashdeploy.rb
+++ b/lib/slashdeploy.rb
@@ -1,4 +1,5 @@
 require 'slash'
+require 'hookshot'
 
 # SlashDeployer is the core API of the SlashDeploy service.
 module SlashDeploy
@@ -100,6 +101,16 @@ module SlashDeploy
 
     def service
       @service ||= Service.new
+    end
+
+    def slack_commands
+      Commands.slack
+    end
+
+    def github_webhooks
+      router = Hookshot::Router.new
+      router.handle :push, PushEvent.new(service)
+      router
     end
 
     def app

--- a/lib/slashdeploy/deployer/fake.rb
+++ b/lib/slashdeploy/deployer/fake.rb
@@ -14,6 +14,7 @@ module SlashDeploy
       # rubocop:disable Style/MethodName
       def HEAD(repo, ref, commit)
         commits[repo][ref] = commit
+        commits[repo][commit] = commit
       end
 
       def create_deployment(user, req)

--- a/spec/features/auto_deploy_spec.rb
+++ b/spec/features/auto_deploy_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.feature 'Slash Commands' do
+  fixtures :all
+  include Rack::Test::Methods
+  let(:app) { SlashDeploy.app }
+
+  before do
+    deployer.reset
+    Repository.create!(name: 'remind101/acme-inc', github_secret: 'secret')
+  end
+
+  scenario 'receiving a `push` event from GitHub when the repo is not enabled for auto deployments' do
+    event \
+      :push,
+      'secret',
+      ref: 'refs/heads/master',
+      repository: {
+        full_name: 'remind101/acme-inc'
+      }
+    expect(last_response.status).to eq 200
+  end
+
+  scenario 'receiving a `push` event from GitHub when the production environment is configured to auto deploy the master branch' do
+    repo = Repository.with_name('remind101/acme-inc')
+    environment = repo.environment('production')
+    environment.configure_auto_deploy('master', user: users(:david))
+
+    HEAD('remind101/acme-inc', 'master', '338e2fca7e65fa01f41f415b3add48af')
+
+    expect do
+      event \
+        :push,
+        'secret',
+        ref: 'refs/heads/master',
+        head: '338e2fca7e65fa01f41f415b3add48af',
+        repository: {
+          full_name: 'remind101/acme-inc'
+        }
+    end.to change { deployment_requests.count }.by(1)
+    expect(last_response.status).to eq 200
+    expect(deployment_requests).to eq [
+      [users(:david), DeploymentRequest.new(repository: 'remind101/acme-inc', ref: '338e2fca7e65fa01f41f415b3add48af', environment: 'production')]
+    ]
+  end
+
+  def event(event, secret, payload = {})
+    body = payload.to_json
+    post \
+      '/',
+      body,
+      Hookshot::HEADER_GITHUB_EVENT => event,
+      Hookshot::HEADER_HUB_SIGNATURE => "sha1=#{Hookshot.signature(body, secret)}"
+  end
+
+  def deployment_requests
+    deployer.requests
+  end
+
+  def deployer
+    SlashDeploy.service.deployer
+  end
+
+  # rubocop:disable Style/MethodName
+  def HEAD(repository, ref, sha)
+    deployer.HEAD(repository, ref, sha)
+  end
+end

--- a/spec/features/auto_deploy_spec.rb
+++ b/spec/features/auto_deploy_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature 'Slash Commands' do
   scenario 'receiving a `push` event from GitHub when the production environment is configured to auto deploy the master branch' do
     repo = Repository.with_name('remind101/acme-inc')
     environment = repo.environment('production')
-    environment.configure_auto_deploy('master')
+    environment.configure_auto_deploy('refs/heads/master')
 
     HEAD('remind101/acme-inc', 'master', '338e2fca7e65fa01f41f415b3add48af')
 
@@ -50,7 +50,7 @@ RSpec.feature 'Slash Commands' do
   scenario 'receiving a `push` event from GitHub from a user that has never logged into slashdeploy' do
     repo = Repository.with_name('remind101/acme-inc')
     environment = repo.environment('production')
-    environment.configure_auto_deploy('master', fallback_user: users(:steve))
+    environment.configure_auto_deploy('refs/heads/master', fallback_user: users(:steve))
 
     HEAD('remind101/acme-inc', 'master', '338e2fca7e65fa01f41f415b3add48af')
 

--- a/spec/github/github_event_handler_spec.rb
+++ b/spec/github/github_event_handler_spec.rb
@@ -1,16 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe GithubEventHandler do
-  let(:slashdeploy) { double(SlashDeploy::Service) }
   let(:handler) do
     Class.new(GithubEventHandler) do
-      attr_reader :repository, :event
-
-      def run(repository, event)
-        @repository = repository
-        @event = event
+      def run
       end
-    end.new slashdeploy
+    end
   end
 
   describe '#call' do
@@ -51,7 +46,7 @@ RSpec.describe GithubEventHandler do
 
     context 'when the signature matches' do
       it 'returns a 200 and calls the handler' do
-        repo = Repository.create!(name: 'remind101/acme-inc', github_secret: 'secret')
+        Repository.create!(name: 'remind101/acme-inc', github_secret: 'secret')
         req = Rack::MockRequest.new(handler)
         resp = req.post \
           '/',
@@ -63,8 +58,6 @@ RSpec.describe GithubEventHandler do
           'CONTENT_TYPE' => 'application/json',
           'HTTP_X_HUB_SIGNATURE' => 'sha1=692ed45ae7de94533457e9d4931389f02a189e1f'
         expect(resp.status).to eq 200
-        expect(handler.repository).to eq repo
-        expect(handler.event['repository']['full_name']).to eq 'remind101/acme-inc'
       end
     end
   end

--- a/spec/github/github_event_handler_spec.rb
+++ b/spec/github/github_event_handler_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe GithubEventHandler do
+  let(:slashdeploy) { double(SlashDeploy::Service) }
+  let(:handler) do
+    Class.new(GithubEventHandler) do
+      attr_reader :repository, :event
+
+      def run(repository, event)
+        @repository = repository
+        @event = event
+      end
+    end.new slashdeploy
+  end
+
+  describe '#call' do
+    context 'when the repo is not found' do
+      # This should never actually happen. If it does, it means something is
+      # misconfigured.
+      it 'raises an error' do
+        req = Rack::MockRequest.new(handler)
+        expect do
+          req.post \
+            '/',
+            input: {
+              repository: {
+                full_name: 'remind101/acme-inc'
+              }
+            }.to_json,
+            'CONTENT_TYPE' => 'application/json'
+        end.to raise_error GithubEventHandler::UnknownRepository
+      end
+    end
+
+    context 'when the signature does not match' do
+      it 'returns a 403' do
+        Repository.create!(name: 'remind101/acme-inc', github_secret: 'secret')
+        req = Rack::MockRequest.new(handler)
+        resp = req.post \
+          '/',
+          input: {
+            repository: {
+              full_name: 'remind101/acme-inc'
+            }
+          }.to_json,
+          'CONTENT_TYPE' => 'application/json',
+          'HTTP_X_HUB_SIGNATURE' => 'sha1=abcd'
+        expect(resp.status).to eq 403
+      end
+    end
+
+    context 'when the signature matches' do
+      it 'returns a 200 and calls the handler' do
+        repo = Repository.create!(name: 'remind101/acme-inc', github_secret: 'secret')
+        req = Rack::MockRequest.new(handler)
+        resp = req.post \
+          '/',
+          input: {
+            repository: {
+              full_name: 'remind101/acme-inc'
+            }
+          }.to_json,
+          'CONTENT_TYPE' => 'application/json',
+          'HTTP_X_HUB_SIGNATURE' => 'sha1=692ed45ae7de94533457e9d4931389f02a189e1f'
+        expect(resp.status).to eq 200
+        expect(handler.repository).to eq repo
+        expect(handler.event['repository']['full_name']).to eq 'remind101/acme-inc'
+      end
+    end
+  end
+end

--- a/spec/hookshot/router_spec.rb
+++ b/spec/hookshot/router_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+RSpec.describe Hookshot::Router do
+  describe '#call' do
+    it 'routes to the correct apps' do
+      router = Hookshot::Router.new
+      router.handle :push, -> (_env) { [200, {}, ['push event']] }
+      router.handle :deployment, -> (_env) { [200, {}, ['deployment event']] }
+
+      status, _headers, body = router.call(env_for_event('push'))
+      expect(status).to eq 200
+      expect(body).to eq ['push event']
+
+      status, _headers, body = router.call(env_for_event('deployment'))
+      expect(status).to eq 200
+      expect(body).to eq ['deployment event']
+
+      status, _headers, _body = router.call(env_for_event('ping'))
+      expect(status).to eq 404
+    end
+  end
+
+  def env_for_event(event)
+    env = Rack::MockRequest.env_for('/')
+    env['HTTP_X_GITHUB_EVENT'] = event
+    env
+  end
+end

--- a/spec/hookshot_spec.rb
+++ b/spec/hookshot_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+RSpec.describe Hookshot do
+  describe '.signature' do
+    it 'calculates the signature' do
+      signature = Hookshot.signature '{"event":"data"}', '1234'
+      expect(signature).to eq 'ade133892a181fba3a21c163cd5cbc3f5f8e915c'
+    end
+  end
+end


### PR DESCRIPTION
This allows you to configure an environment to auto deploy a branch when it's pushed to on GitHub. This is just a phase 1 approach that doesn't take commit statuses into account.

Next version will allow you to configure the commit status contexts that should be passing before deploying.

**TODO**

* [ ] Ignore forks
* [ ] Ignore tags.