### PR TITLE
Allow default ref and environment to be overriden.

### DIFF
--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -44,6 +44,10 @@ class Environment < ActiveRecord::Base
 
   # The default git ref to deploy when none is provided for this environment.
   def default_ref
+    super.presence || self.class.default_ref
+  end
+
+  def self.default_ref
     Rails.configuration.x.default_ref
   end
 

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -11,7 +11,12 @@ class Repository < ActiveRecord::Base
   # Finds the associated environment with the given name, creating it if
   # necessary. If name is nil, returns the default environment.
   def environment(name = nil)
-    environments.with_name(name || self.class.default_environment)
+    environments.with_name(name || default_environment)
+  end
+
+  # The default environment to deploy to when one is not specified.
+  def default_environment
+    super.presence || self.class.default_environment
   end
 
   # The name of the default environment for a repository.

--- a/db/migrate/20160211061750_add_defaults_to_repositories_and_environments.rb
+++ b/db/migrate/20160211061750_add_defaults_to_repositories_and_environments.rb
@@ -1,0 +1,6 @@
+class AddDefaultsToRepositoriesAndEnvironments < ActiveRecord::Migration
+  def change
+    add_column :repositories, :default_environment, :string
+    add_column :environments, :default_ref, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -40,7 +40,8 @@ CREATE TABLE environments (
     updated_at timestamp without time zone NOT NULL,
     repository_id integer NOT NULL,
     in_channel boolean DEFAULT false NOT NULL,
-    aliases text[] DEFAULT '{}'::text[]
+    aliases text[] DEFAULT '{}'::text[],
+    default_ref character varying
 );
 
 
@@ -117,7 +118,8 @@ CREATE TABLE repositories (
     id integer NOT NULL,
     name character varying NOT NULL,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    default_environment character varying
 );
 
 
@@ -410,4 +412,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160209012632');
 INSERT INTO schema_migrations (version) VALUES ('20160210071446');
 
 INSERT INTO schema_migrations (version) VALUES ('20160210094548');
+
+INSERT INTO schema_migrations (version) VALUES ('20160211061750');
 

--- a/spec/models/environment_spec.rb
+++ b/spec/models/environment_spec.rb
@@ -80,4 +80,23 @@ RSpec.describe Environment, type: :model do
       expect(staging.errors[:name]).to eq ['includes the name of an existing environment for this repository']
     end
   end
+
+  describe '#default_ref' do
+    context 'when the environment has a default ref provided' do
+      it 'returns that value' do
+        environment = Environment.new(default_ref: 'develop')
+        expect(environment.default_ref).to eq 'develop'
+      end
+    end
+
+    context 'when the environment does not have a default ref' do
+      it 'returns the global default' do
+        environment = Environment.new(default_ref: '')
+        expect(environment.default_ref).to eq 'master'
+
+        environment = Environment.new
+        expect(environment.default_ref).to eq 'master'
+      end
+    end
+  end
 end

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -28,4 +28,23 @@ RSpec.describe Repository, type: :model do
       end
     end
   end
+
+  describe '#default_environment' do
+    context 'when the repository has a default environment provided' do
+      it 'returns that value' do
+        repo = Repository.new(default_environment: 'staging')
+        expect(repo.default_environment).to eq 'staging'
+      end
+    end
+
+    context 'when the repository does not have a default environment' do
+      it 'returns production' do
+        repo = Repository.new(default_environment: '')
+        expect(repo.default_environment).to eq 'production'
+
+        repo = Repository.new
+        expect(repo.default_environment).to eq 'production'
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes https://github.com/ejholmes/slashdeploy/issues/4

This allows the global defaults to be overridden per repo and environment. This makes it possible to have a different default ref per environment (e.g. `master` when deploying to `production` and `develop` when deploying to `staging` or whatever).