### PR TITLE
Auto deploy warning

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,3 +30,9 @@ Style/Send:
 
 Style/NumericLiterals:
   Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Metrics/PerceivedComplexity:
+  Enabled: false

--- a/app/commands/deploy_command.rb
+++ b/app/commands/deploy_command.rb
@@ -13,6 +13,8 @@ class DeployCommand < BaseCommand
           force: params['force']
         )
         respond env.in_channel?, :created, resp: resp
+      rescue SlashDeploy::EnvironmentAutoDeploys
+        reply :auto_deploy, environment: env
       rescue SlashDeploy::RedCommitError => e
         reply :red_commit, failing_contexts: e.failing_contexts
       rescue SlashDeploy::EnvironmentLockedError => e

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -54,8 +54,14 @@ class Environment < ActiveRecord::Base
     self.update_attributes!(auto_deploy_ref: ref, auto_deploy_user: options[:fallback_user])
   end
 
+  # Checks if this environment is configured to automatically deploy the given ref.
   def auto_deploy?(ref)
     auto_deploy_ref == ref
+  end
+
+  # Returns true if this environment is configured to automatically deploy.
+  def auto_deploy_enabled?
+    auto_deploy_ref.present?
   end
 
   # The default git ref to deploy when none is provided for this environment.

--- a/app/views/commands/deploy/auto_deploy.text.erb
+++ b/app/views/commands/deploy/auto_deploy.text.erb
@@ -1,0 +1,1 @@
+<%= @environment.repository %> is configured to automatically deploy `<%= @environment.auto_deploy_ref %>` to `<%= @environment %>`. You can bypass this warning with `<%= @request.command %> <%= @request.text %>!`

--- a/lib/slashdeploy.rb
+++ b/lib/slashdeploy.rb
@@ -64,6 +64,8 @@ module SlashDeploy
 
   Error = Class.new(StandardError)
 
+  EnvironmentAutoDeploys = Class.new(Error)
+
   # Raised when a user doesn't have access to the given repo.
   class RepoUnauthorized < Error
     attr_reader :repository

--- a/lib/slashdeploy/service.rb
+++ b/lib/slashdeploy/service.rb
@@ -25,14 +25,18 @@ module SlashDeploy
     #
     # Returns a DeploymentResponse.
     def create_deployment(user, environment, ref = nil, options = {})
+      force = options[:force]
       repository = environment.repository
 
       req = DeploymentRequest.new(
         repository:  repository.to_s,
         environment: environment.to_s,
         ref:         ref || environment.default_ref,
-        force:       options[:force]
+        force:       force
       )
+
+      # Check if the environment we're deploying to is configured for auto deployments.
+      fail EnvironmentAutoDeploys if environment.auto_deploy_enabled? && !force
 
       # Check if the environment we're deploying to is locked.
       lock = environment.active_lock

--- a/spec/features/add_to_slack_spec.rb
+++ b/spec/features/add_to_slack_spec.rb
@@ -2,8 +2,6 @@ require 'rails_helper'
 
 RSpec.feature 'Add to Slack' do
   fixtures :all
-  include Rack::Test::Methods
-  let(:app) { SlashDeploy.app }
 
   scenario 'clicking the Add to Slack button' do
     stub_request(:post, 'https://slack.com/api/oauth.access')

--- a/spec/features/commands_spec.rb
+++ b/spec/features/commands_spec.rb
@@ -2,8 +2,6 @@ require 'rails_helper'
 
 RSpec.feature 'Slash Commands' do
   fixtures :all
-  include Rack::Test::Methods
-  let(:app) { SlashDeploy.app }
 
   before do
     deployer.reset
@@ -28,19 +26,19 @@ RSpec.feature 'Slash Commands' do
     )
 
     command '/deploy help', as: account
-    state = response.text.gsub(/^.*state=(.*?)\|.*$/, '\\1')
+    state = command_response.text.gsub(/^.*state=(.*?)\|.*$/, '\\1')
     expect do
       visit "/auth/github/callback?state=#{state}&code=code"
     end.to change { User.count }.by(1)
 
     command '/deploy help', as: account
-    expect(response.text).to eq HelpCommand::USAGE.strip
+    expect(command_response.text).to eq HelpCommand::USAGE.strip
   end
 
   scenario 'entering an unknown command' do
     command '/deploy foo', as: slack_accounts(:bob)
-    expect(response.in_channel).to be_falsey
-    expect(response.text).to eq "I don't know that command. Here's what I do know:\n#{HelpCommand::USAGE}".strip
+    expect(command_response.in_channel).to be_falsey
+    expect(command_response.text).to eq "I don't know that command. Here's what I do know:\n#{HelpCommand::USAGE}".strip
   end
 
   scenario 'performing a simple deployment' do
@@ -48,14 +46,14 @@ RSpec.feature 'Slash Commands' do
     expect(deployment_requests).to eq [
       [users(:david), DeploymentRequest.new(repository: 'remind101/acme-inc', ref: 'master', environment: 'production')]
     ]
-    expect(response).to be_in_channel
-    expect(response.text).to eq 'Created deployment request for <https://github.com/remind101/acme-inc|remind101/acme-inc>@<https://github.com/remind101/acme-inc/commits/ad80a1b3e1a94b98ce99b71a48f811f1|master> to production (no change)'
+    expect(command_response).to be_in_channel
+    expect(command_response.text).to eq 'Created deployment request for <https://github.com/remind101/acme-inc|remind101/acme-inc>@<https://github.com/remind101/acme-inc/commits/ad80a1b3e1a94b98ce99b71a48f811f1|master> to production (no change)'
 
     # David commits something new
     HEAD('remind101/acme-inc', 'master', 'f5c0df18526b90b9698816ee4b6606e0')
 
     command '/deploy remind101/acme-inc', as: slack_accounts(:david)
-    expect(response.text).to eq 'Created deployment request for <https://github.com/remind101/acme-inc|remind101/acme-inc>@<https://github.com/remind101/acme-inc/commits/f5c0df18526b90b9698816ee4b6606e0|master> to production (<https://github.com/remind101/acme-inc/compare/ad80a1...f5c0df|diff>)'
+    expect(command_response.text).to eq 'Created deployment request for <https://github.com/remind101/acme-inc|remind101/acme-inc>@<https://github.com/remind101/acme-inc/commits/f5c0df18526b90b9698816ee4b6606e0|master> to production (<https://github.com/remind101/acme-inc/compare/ad80a1...f5c0df|diff>)'
   end
 
   scenario 'performing a deployment to a specific environment' do
@@ -96,7 +94,7 @@ RSpec.feature 'Slash Commands' do
       command '/deploy remind101/acme-inc@failing', as: slack_accounts(:david)
     end.to_not change { deployment_requests }
 
-    expect(response.text).to eq <<-TEXT.strip_heredoc.strip
+    expect(command_response.text).to eq <<-TEXT.strip_heredoc.strip
     The following commit status checks failed:
     * ci
     You can ignore commit status checks by using `/deploy remind101/acme-inc@failing!`
@@ -109,13 +107,13 @@ RSpec.feature 'Slash Commands' do
 
   scenario 'locking a branch' do
     command '/deploy lock staging on remind101/acme-inc', as: slack_accounts(:david)
-    expect(response.text).to eq 'Locked `staging` on remind101/acme-inc'
+    expect(command_response.text).to eq 'Locked `staging` on remind101/acme-inc'
 
     # Other users shouldn't be able to deploy now.
     expect do
       command '/deploy remind101/acme-inc to staging', as: slack_accounts(:steve)
     end.to_not change { deployment_requests }
-    expect(response.text).to eq '`staging` is locked by <@david>'
+    expect(command_response.text).to eq '`staging` is locked by <@david>'
 
     # But david should be able to deploy.
     expect do
@@ -123,7 +121,7 @@ RSpec.feature 'Slash Commands' do
     end.to change { deployment_requests.count }.by(1)
 
     command '/deploy unlock staging on remind101/acme-inc', as: slack_accounts(:david)
-    expect(response.text).to eq 'Unlocked `staging` on remind101/acme-inc'
+    expect(command_response.text).to eq 'Unlocked `staging` on remind101/acme-inc'
 
     # Now other users should be able to deploy
     expect do
@@ -133,24 +131,24 @@ RSpec.feature 'Slash Commands' do
 
   scenario 'locking a branch with a message' do
     command "/deploy lock staging on remind101/acme-inc: I'm testing some stuff", as: slack_accounts(:david)
-    expect(response.text).to eq 'Locked `staging` on remind101/acme-inc'
+    expect(command_response.text).to eq 'Locked `staging` on remind101/acme-inc'
 
     # Other users shouldn't be able to deploy now.
     expect do
       command '/deploy remind101/acme-inc to staging', as: slack_accounts(:steve)
     end.to_not change { deployment_requests }
-    expect(response.text).to eq "`staging` is locked by <@david>: I'm testing some stuff"
+    expect(command_response.text).to eq "`staging` is locked by <@david>: I'm testing some stuff"
   end
 
   scenario 'stealing a lock' do
     command '/deploy lock staging on remind101/acme-inc', as: slack_accounts(:david)
-    expect(response.text).to eq 'Locked `staging` on remind101/acme-inc'
+    expect(command_response.text).to eq 'Locked `staging` on remind101/acme-inc'
 
     command '/deploy lock staging on remind101/acme-inc', as: slack_accounts(:david)
-    expect(response.text).to eq '`staging` is already locked'
+    expect(command_response.text).to eq '`staging` is already locked'
 
     command '/deploy lock staging on remind101/acme-inc', as: slack_accounts(:steve)
-    expect(response.text).to eq 'Locked `staging` on remind101/acme-inc (stolen from <@david>)'
+    expect(command_response.text).to eq 'Locked `staging` on remind101/acme-inc (stolen from <@david>)'
 
     expect do
       command '/deploy remind101/acme-inc to staging', as: slack_accounts(:david)
@@ -159,17 +157,17 @@ RSpec.feature 'Slash Commands' do
 
   scenario 'trying to do something on a repo I dont have access to' do
     command '/deploy lock staging on remind101/acme-inc', as: slack_accounts(:bob)
-    expect(response.text).to eq "Sorry, but it looks like you don't have access to remind101/acme-inc"
+    expect(command_response.text).to eq "Sorry, but it looks like you don't have access to remind101/acme-inc"
   end
 
   scenario 'finding the environments I can deploy a repo to' do
     command '/deploy where remind101/acme-inc', as: slack_accounts(:david)
-    expect(response.text).to eq "I don't know about any environments for remind101/acme-inc"
+    expect(command_response.text).to eq "I don't know about any environments for remind101/acme-inc"
 
     command '/deploy remind101/acme-inc to staging', as: slack_accounts(:david)
 
     command '/deploy where remind101/acme-inc', as: slack_accounts(:david)
-    expect(response.text).to eq <<-TEXT.strip_heredoc.strip
+    expect(command_response.text).to eq <<-TEXT.strip_heredoc.strip
     I know about these environments for remind101/acme-inc:
     * staging
     TEXT
@@ -177,7 +175,7 @@ RSpec.feature 'Slash Commands' do
 
   xscenario 'debugging exception tracking' do
     command '/deploy boom', as: slack_accounts(:david)
-    expect(response.text).to eq "Oops! We had a problem running your command, but we've been notified"
+    expect(command_response.text).to eq "Oops! We had a problem running your command, but we've been notified"
   end
 
   def deployment_requests
@@ -191,28 +189,5 @@ RSpec.feature 'Slash Commands' do
   # rubocop:disable Style/MethodName
   def HEAD(repository, ref, sha)
     deployer.HEAD(repository, ref, sha)
-  end
-
-  def command(text, options = {})
-    slack_account = options[:as]
-
-    command, *text = text.split(' ')
-    post \
-      '/commands',
-      command:     command,
-      text:        text.join(' '),
-      token:       Rails.configuration.x.slack.verification_token,
-      user_id:     slack_account.id,
-      user_name:   slack_account.user_name,
-      team_id:     slack_account.team_id,
-      team_domain: slack_account.team_domain
-  end
-
-  def response
-    body = JSON.parse(last_response.body)
-    Slash::Response.new(
-      text: body['text'],
-      in_channel: body['response_type'] == 'in_channel'
-    )
   end
 end

--- a/spec/features/commands_spec.rb
+++ b/spec/features/commands_spec.rb
@@ -173,6 +173,21 @@ RSpec.feature 'Slash Commands' do
     TEXT
   end
 
+  scenario 'trying to /deploy an environment that is configured to auto deploy', focus: true do
+    repo = Repository.with_name('remind101/acme-inc')
+    environment = repo.environment('production')
+    environment.configure_auto_deploy('refs/heads/master')
+
+    expect do
+      command '/deploy remind101/acme-inc@master', as: slack_accounts(:david)
+    end.to_not change { deployment_requests }
+    expect(command_response.text).to eq 'remind101/acme-inc is configured to automatically deploy `refs/heads/master` to `production`. You can bypass this warning with `/deploy remind101/acme-inc@master!`'
+
+    expect do
+      command '/deploy remind101/acme-inc@master!', as: slack_accounts(:david)
+    end.to change { deployment_requests.count }.by(1)
+  end
+
   xscenario 'debugging exception tracking' do
     command '/deploy boom', as: slack_accounts(:david)
     expect(command_response.text).to eq "Oops! We had a problem running your command, but we've been notified"

--- a/spec/fixtures/repositories.yml
+++ b/spec/fixtures/repositories.yml
@@ -1,0 +1,3 @@
+'baxterthehacker/public-repo':
+  name: 'baxterthehacker/public-repo'
+  github_secret: secret

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -54,4 +54,7 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  require_relative '../spec/support/features'
+  config.include Features, type: :feature
 end

--- a/spec/support/features.rb
+++ b/spec/support/features.rb
@@ -10,6 +10,8 @@ module Features
   def command(text, options = {})
     slack_account = options[:as]
 
+    fail "The :as option expects a SlackAccount to be provided, but you provided a #{slack_account.class}." if slack_account && !slack_account.is_a?(SlackAccount)
+
     command, *text = text.split(' ')
     post \
       '/commands',

--- a/spec/support/features.rb
+++ b/spec/support/features.rb
@@ -1,0 +1,58 @@
+# This module gets included into full stack feature specs in spec/features.
+module Features
+  include Rack::Test::Methods
+
+  def app
+    SlashDeploy.app
+  end
+
+  # Runs a / command as the given slack account.
+  def command(text, options = {})
+    slack_account = options[:as]
+
+    command, *text = text.split(' ')
+    post \
+      '/commands',
+      command:     command,
+      text:        text.join(' '),
+      token:       Rails.configuration.x.slack.verification_token,
+      user_id:     slack_account.id,
+      user_name:   slack_account.user_name,
+      team_id:     slack_account.team_id,
+      team_domain: slack_account.team_domain
+  end
+
+  # Returns the last Slash::Response.
+  def command_response
+    body = JSON.parse(last_response.body)
+    Slash::Response.new(
+      text: body['text'],
+      in_channel: body['response_type'] == 'in_channel'
+    )
+  end
+
+  # Triggers a github event against SlashDeploy.
+  def github_event(event, secret, payload = {})
+    body = payload.to_json
+    post \
+      '/',
+      body,
+      Hookshot::HEADER_GITHUB_EVENT => event,
+      Hookshot::HEADER_HUB_SIGNATURE => "sha1=#{Hookshot.signature(body, secret)}"
+  end
+
+  def status_event(secret, extra = {})
+    data = fixture('status_event.json')
+    github_event :status, secret, data.deep_merge(extra.stringify_keys)
+  end
+
+  def push_event(secret, extra = {})
+    data = fixture('push_event.json')
+    github_event :push, secret, data.deep_merge(extra.stringify_keys)
+  end
+
+  def fixture(name)
+    fname = File.expand_path("../fixtures/github/#{name}", __dir__)
+    JSON.parse File.read(fname)
+  end
+end


### PR DESCRIPTION
Closes https://github.com/ejholmes/slashdeploy/issues/42

If auto deployment is enabled on the environment, it'll warn the user and they can use `!` to bypass it.