### PR TITLE
Refine lock stealing.

### DIFF
--- a/app/commands/lock_command.rb
+++ b/app/commands/lock_command.rb
@@ -4,12 +4,16 @@ class LockCommand < BaseCommand
     transaction do
       repo = Repository.with_name(params['repository'])
       env  = repo.environment(params['environment'])
-      resp = slashdeploy.lock_environment(user.user, env, params['message'].try(:strip))
-      if resp
-        stealer = resp.stolen ? SlackUser.new(resp.stolen.user, user.slack_team) : nil
-        say :locked, environment: env, repository: repo, stealer: stealer
-      else
-        say :already_locked, environment: env, repository: repo
+      begin
+        resp = slashdeploy.lock_environment(user.user, env, message: params['message'].try(:strip), force: params['force'])
+        if resp
+          stealer = resp.stolen ? SlackUser.new(resp.stolen.user, user.slack_team) : nil
+          say :locked, environment: env, repository: repo, stealer: stealer
+        else
+          say :already_locked, environment: env, repository: repo
+        end
+      rescue SlashDeploy::EnvironmentLockedError => e
+        say :lock, environment: env, repository: repo, lock: e.lock, locker: SlackUser.new(e.lock.user, user.slack_team)
       end
     end
   end

--- a/app/commands/slash_commands.rb
+++ b/app/commands/slash_commands.rb
@@ -14,7 +14,7 @@ class SlashCommands
     router = Slash::Router.new
     router.match match_regexp(/^help$/), HelpCommand
     router.match match_regexp(/^where #{REPO}$/), EnvironmentsCommand
-    router.match match_regexp(/^lock #{ENV} on #{REPO}(:(?<message>.*))?$/), LockCommand
+    router.match match_regexp(/^lock #{ENV} on #{REPO}(:(?<message>.*))?(?<force>!)?$/), LockCommand
     router.match match_regexp(/^unlock #{ENV} on #{REPO}$/), UnlockCommand
     router.match match_regexp(/^boom$/), BoomCommand
     router.match match_regexp(/^#{REPO}(@#{REF})?( to #{ENV})?(?<force>!)?$/), DeployCommand

--- a/app/views/commands/lock/lock.text.erb
+++ b/app/views/commands/lock/lock.text.erb
@@ -1,0 +1,1 @@
+`<%= @environment %>` on <%= @repository %> is locked by <@<%= @locker.slack_username %>>. You can steal the lock with `<%= @request.command %> <%= @request.text %>!`.

--- a/lib/slashdeploy/service.rb
+++ b/lib/slashdeploy/service.rb
@@ -51,21 +51,24 @@ module SlashDeploy
     # Attempts to lock the environment on the repo.
     #
     # environment - An Environment to lock.
-    # message     - An option message.
+    # options     - A hash of options.
+    #               :message - An optional message.
+    #               :force   - Steal the lock if the environment is already locked.
     #
     # Returns a Lock.
-    def lock_environment(user, environment, message = nil)
+    def lock_environment(user, environment, options = {})
       authorize! user, environment.repository
 
       lock = environment.active_lock
 
       if lock
         return if lock.user == user # Already locked, nothing to do.
+        fail EnvironmentLockedError, lock unless options[:force]
         lock.unlock!
       end
 
       stolen = lock
-      lock = environment.lock! user, message
+      lock = environment.lock! user, options[:message]
 
       LockResponse.new \
         lock: lock,

--- a/spec/commands/slash_commands_spec.rb
+++ b/spec/commands/slash_commands_spec.rb
@@ -13,9 +13,10 @@ RSpec.describe SlashCommands do
       check_route(a, 'where acme-inc/api', EnvironmentsCommand, 'repository' => 'acme-inc/api')
       check_route(a, 'where api', EnvironmentsCommand, 'repository' => 'acme-inc/api')
 
-      check_route(a, 'lock staging on acme-inc/api: Doing stuff', LockCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging', 'message' => ' Doing stuff')
-      check_route(a, 'lock staging on acme-inc/api', LockCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging', 'message' => nil)
-      check_route(a, 'lock staging on api', LockCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging', 'message' => nil)
+      check_route(a, 'lock staging on acme-inc/api: Doing stuff', LockCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging', 'message' => ' Doing stuff', 'force' => nil)
+      check_route(a, 'lock staging on acme-inc/api', LockCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging', 'message' => nil, 'force' => nil)
+      check_route(a, 'lock staging on api', LockCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging', 'message' => nil, 'force' => nil)
+      check_route(a, 'lock staging on api!', LockCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging', 'message' => nil, 'force' => '!')
 
       check_route(a, 'unlock staging on acme-inc/api', UnlockCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging')
       check_route(a, 'unlock staging on api', UnlockCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging')

--- a/spec/features/commands_spec.rb
+++ b/spec/features/commands_spec.rb
@@ -158,6 +158,13 @@ RSpec.feature 'Slash Commands' do
     expect(command_response.text).to eq '`staging` is already locked'
 
     command '/deploy lock staging on acme-inc/api', as: slack_accounts(:steve)
+    expect(command_response.text).to eq '`staging` on acme-inc/api is locked by <@david>. You can steal the lock with `/deploy lock staging on acme-inc/api!`.'
+
+    expect do
+      command '/deploy acme-inc/api to staging', as: slack_accounts(:steve)
+    end.to_not change { deployment_requests }
+
+    command '/deploy lock staging on acme-inc/api!', as: slack_accounts(:steve)
     expect(command_response.text).to eq 'Locked `staging` on acme-inc/api (stolen from <@david>)'
 
     expect do


### PR DESCRIPTION
Closes https://github.com/ejholmes/slashdeploy/issues/49

This introduces the behavior suggested in https://github.com/ejholmes/slashdeploy/issues/49, so that stealing someone else's lock requires a `!`. This also means you can use the `/deploy lock` command to check if an environment is already locked by someone.