### PR TITLE
add relative lock created_at in deploy/locked.text.erb

### DIFF
--- a/app/views/commands/deploy/locked.text.erb
+++ b/app/views/commands/deploy/locked.text.erb
@@ -1,1 +1,1 @@
-`<%= @environment %>` is locked by <@<%= @locker.slack_username %>><% if @lock.message %>: <%= @lock.message %><% end %>
+`<%= @environment %>` was locked by <@<%= @locker.slack_username %>> <%= time_ago_in_words(@lock.created_at) %> ago<% if @lock.message %>: <%= @lock.message %><% end %>

--- a/spec/features/commands_spec.rb
+++ b/spec/features/commands_spec.rb
@@ -123,7 +123,7 @@ RSpec.feature 'Slash Commands' do
     expect do
       command '/deploy acme-inc/api to staging', as: slack_accounts(:steve)
     end.to_not change { deployment_requests }
-    expect(command_response.text).to eq '`staging` is locked by <@david>'
+    expect(command_response.text).to eq '`staging` was locked by <@david> less than a minute ago'
 
     # But david should be able to deploy.
     expect do
@@ -147,7 +147,7 @@ RSpec.feature 'Slash Commands' do
     expect do
       command '/deploy acme-inc/api to staging', as: slack_accounts(:steve)
     end.to_not change { deployment_requests }
-    expect(command_response.text).to eq "`staging` is locked by <@david>: I'm testing some stuff"
+    expect(command_response.text).to eq "`staging` was locked by <@david> less than a minute ago: I'm testing some stuff"
   end
 
   scenario 'stealing a lock' do


### PR DESCRIPTION
I'm always suspicious about people forgetting to unlock.
This is faster than going thought all the slack channels trying to find the latest `/deploy lock`.