### PR TITLE
Change capitalization of migration class name

### DIFF
--- a/db/migrate/20160209082726_add_github_secret_to_repositories.rb
+++ b/db/migrate/20160209082726_add_github_secret_to_repositories.rb
@@ -1,4 +1,4 @@
-class AddGithubSecretToRepositories < ActiveRecord::Migration
+class AddGitHubSecretToRepositories < ActiveRecord::Migration
   def up
     add_column :repositories, :github_secret, :string
     Repository.reset_column_information


### PR DESCRIPTION
For some reason this migration fails unless the class name is capitalized like this.

Traceback:

```ruby
NameError: uninitialized constant AddGitHubSecretToRepositories
/app/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.5.1/lib/active_support/inflector/methods.rb:261:in `const_get'
/app/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.5.1/lib/active_support/inflector/methods.rb:261:in `block in constantize'
/app/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.5.1/lib/active_support/inflector/methods.rb:259:in `each'
/app/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.5.1/lib/active_support/inflector/methods.rb:259:in `inject'
/app/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.5.1/lib/active_support/inflector/methods.rb:259:in `constantize'
/app/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.5.1/lib/active_support/core_ext/string/inflections.rb:66:in `constantize'
/app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.5.1/lib/active_record/migration.rb:778:in `load_migration'
/app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.5.1/lib/active_record/migration.rb:773:in `migration'
/app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.5.1/lib/active_record/migration.rb:768:in `disable_ddl_transaction'
/app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.5.1/lib/active_record/migration.rb:1051:in `use_transaction?'
/app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.5.1/lib/active_record/migration.rb:961:in `rescue in block in migrate'
/app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.5.1/lib/active_record/migration.rb:958:in `block in migrate'
/app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.5.1/lib/active_record/migration.rb:955:in `each'
/app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.5.1/lib/active_record/migration.rb:955:in `migrate'
/app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.5.1/lib/active_record/migration.rb:823:in `up'
/app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.5.1/lib/active_record/migration.rb:801:in `migrate'
/app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.5.1/lib/active_record/tasks/database_tasks.rb:137:in `migrate'
/app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.5.1/lib/active_record/railties/databases.rake:44:in `block (2 levels) in <top (required)>'
NameError: uninitialized constant AddGitHubSecretToRepositories
/app/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.5.1/lib/active_support/inflector/methods.rb:261:in `const_get'
/app/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.5.1/lib/active_support/inflector/methods.rb:261:in `block in constantize'
/app/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.5.1/lib/active_support/inflector/methods.rb:259:in `each'
/app/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.5.1/lib/active_support/inflector/methods.rb:259:in `inject'
/app/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.5.1/lib/active_support/inflector/methods.rb:259:in `constantize'
/app/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.5.1/lib/active_support/core_ext/string/inflections.rb:66:in `constantize'
/app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.5.1/lib/active_record/migration.rb:778:in `load_migration'
/app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.5.1/lib/active_record/migration.rb:773:in `migration'
/app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.5.1/lib/active_record/migration.rb:768:in `disable_ddl_transaction'
/app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.5.1/lib/active_record/migration.rb:1051:in `use_transaction?'
/app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.5.1/lib/active_record/migration.rb:1043:in `ddl_transaction'
/app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.5.1/lib/active_record/migration.rb:997:in `execute_migration_in_transaction'
/app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.5.1/lib/active_record/migration.rb:959:in `block in migrate'
/app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.5.1/lib/active_record/migration.rb:955:in `each'
/app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.5.1/lib/active_record/migration.rb:955:in `migrate'
/app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.5.1/lib/active_record/migration.rb:823:in `up'
/app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.5.1/lib/active_record/migration.rb:801:in `migrate'
/app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.5.1/lib/active_record/tasks/database_tasks.rb:137:in `migrate'
/app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.5.1/lib/active_record/railties/databases.rake:44:in `block (2 levels) in <top (required)>'
Tasks: TOP => db:migrate
```