### PR TITLE
Use 7 character Git SHAs in the diff URL

### DIFF
--- a/app/models/deployment_response.rb
+++ b/app/models/deployment_response.rb
@@ -17,6 +17,6 @@ class DeploymentResponse
   def diff_url
     return unless last_deployment
     return if deployment.sha == last_deployment.sha
-    "https://github.com/#{deployment.repository}/compare/#{last_deployment.sha[0..5]}...#{deployment.sha[0..5]}"
+    "https://github.com/#{deployment.repository}/compare/#{last_deployment.sha[0..6]}...#{deployment.sha[0..6]}"
   end
 end

--- a/spec/features/commands_spec.rb
+++ b/spec/features/commands_spec.rb
@@ -53,7 +53,7 @@ RSpec.feature 'Slash Commands' do
     HEAD('acme-inc/api', 'master', 'f5c0df18526b90b9698816ee4b6606e0')
 
     command '/deploy acme-inc/api', as: slack_accounts(:david)
-    expect(command_response.text).to eq 'Created deployment request for <https://github.com/acme-inc/api|acme-inc/api>@<https://github.com/acme-inc/api/commits/f5c0df18526b90b9698816ee4b6606e0|master> to production (<https://github.com/acme-inc/api/compare/ad80a1...f5c0df|diff>)'
+    expect(command_response.text).to eq 'Created deployment request for <https://github.com/acme-inc/api|acme-inc/api>@<https://github.com/acme-inc/api/commits/f5c0df18526b90b9698816ee4b6606e0|master> to production (<https://github.com/acme-inc/api/compare/ad80a1b...f5c0df1|diff>)'
   end
 
   scenario 'performing a deployment to a specific environment' do


### PR DESCRIPTION
We can't see diffs for many r101-api deploys:

![commits not found](http://s.goobtown.net/ag9zfmdvb2JzaG90cy1ocmRyEQsSBFNob3QYgICAgIOEjQoM)

Seems like we're hitting SHA conflicts. I see GitHub uses 7 character SHAs in many places. Let's try using those?