### PR TITLE
Show time the lock was created.

### DIFF
--- a/app/views/commands/lock/lock.text.erb
+++ b/app/views/commands/lock/lock.text.erb
@@ -1,1 +1,1 @@
-`<%= @environment %>` on <%= @repository %> is locked by <@<%= @locker.slack_username %>>. You can steal the lock with `<%= @request.command %> <%= @request.text %>!`.
+`<%= @environment %>` on <%= @repository %> was locked by <@<%= @locker.slack_username %>> <%= time_ago_in_words(@lock.created_at) %> ago. You can steal the lock with `<%= @request.command %> <%= @request.text %>!`.

--- a/spec/features/commands_spec.rb
+++ b/spec/features/commands_spec.rb
@@ -158,7 +158,7 @@ RSpec.feature 'Slash Commands' do
     expect(command_response.text).to eq '`staging` is already locked'
 
     command '/deploy lock staging on acme-inc/api', as: slack_accounts(:steve)
-    expect(command_response.text).to eq '`staging` on acme-inc/api is locked by <@david>. You can steal the lock with `/deploy lock staging on acme-inc/api!`.'
+    expect(command_response.text).to eq '`staging` on acme-inc/api was locked by <@david> less than a minute ago. You can steal the lock with `/deploy lock staging on acme-inc/api!`.'
 
     expect do
       command '/deploy acme-inc/api to staging', as: slack_accounts(:steve)


### PR DESCRIPTION
Closes https://github.com/ejholmes/slashdeploy/issues/58

Makes it easier to see if someone forgot to unlock an environment:

```
/deploy on staging on acme-inc
staging on acme-inc was locked by @foo 2 days ago...
```