### PR TITLE
DM user when auto deployments are started by them

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,9 @@ AllCops:
 Metrics/LineLength:
   Enabled: false
 
+Metrics/ClassLength:
+  Enabled: false
+
 Metrics/MethodLength:
   Enabled: false
 

--- a/app/messages/auto_deployment_created_message.rb
+++ b/app/messages/auto_deployment_created_message.rb
@@ -1,0 +1,10 @@
+class AutoDeploymentCreatedMessage < SlackMessage
+  values do
+    attribute :account, SlackAccount
+    attribute :auto_deployment, AutoDeployment
+  end
+
+  def to_message
+    Slack::Message.new text: text
+  end
+end

--- a/app/messages/auto_deployment_environment_locked_message.rb
+++ b/app/messages/auto_deployment_environment_locked_message.rb
@@ -1,0 +1,10 @@
+class AutoDeploymentEnvironmentLockedMessage < SlackMessage
+  values do
+    attribute :account, SlackAccount
+    attribute :auto_deployment, AutoDeployment
+  end
+
+  def to_message
+    Slack::Message.new text: text
+  end
+end

--- a/app/messages/auto_deployment_failed_message.rb
+++ b/app/messages/auto_deployment_failed_message.rb
@@ -1,0 +1,11 @@
+class AutoDeploymentFailedMessage < SlackMessage
+  values do
+    attribute :account, SlackAccount
+    attribute :auto_deployment, AutoDeployment
+    attribute :commit_status_context, CommitStatusContext
+  end
+
+  def to_message
+    Slack::Message.new text: text
+  end
+end

--- a/app/messages/auto_deployment_started_message.rb
+++ b/app/messages/auto_deployment_started_message.rb
@@ -1,0 +1,10 @@
+class AutoDeploymentStartedMessage < SlackMessage
+  values do
+    attribute :account, SlackAccount
+    attribute :auto_deployment, AutoDeployment
+  end
+
+  def to_message
+    Slack::Message.new text: text
+  end
+end

--- a/app/models/commit_status_context.rb
+++ b/app/models/commit_status_context.rb
@@ -14,9 +14,14 @@ class CommitStatusContext
   end
 
   def success?
-    state == 'success'
+    state == SUCCESS
   end
 
+  def bad?
+    state == FAILURE || state == ERROR
+  end
+
+  # TODO: Wat?
   def failure?
     !success?
   end

--- a/app/views/messages/auto_deployment_created.text.erb
+++ b/app/views/messages/auto_deployment_created.text.erb
@@ -1,0 +1,1 @@
+Hey @<%= @account.user_name %>. I'll start a deployment of <%= @auto_deployment.environment.repository %>@<%= @auto_deployment.sha %> to <%= @auto_deployment.environment %> for you once commit statuses are passing.

--- a/app/views/messages/auto_deployment_environment_locked.text.erb
+++ b/app/views/messages/auto_deployment_environment_locked.text.erb
@@ -1,0 +1,1 @@
+Hey @<%= @account.user_name %>. I was going to start a deployment of <%= @auto_deployment.environment.repository %>@<%= @auto_deployment.sha %> to <%= @auto_deployment.environment %> for you, but <%= @auto_deployment.environment %> is locked.

--- a/app/views/messages/auto_deployment_failed.text.erb
+++ b/app/views/messages/auto_deployment_failed.text.erb
@@ -1,0 +1,1 @@
+Hey @<%= @account.user_name %>. I was going to start a deployment of <%= @auto_deployment.environment.repository %>@<%= @auto_deployment.sha %> to <%= @auto_deployment.environment %> for you, but *<%= @commit_status_context.context %>* failed.

--- a/app/views/messages/auto_deployment_started.text.erb
+++ b/app/views/messages/auto_deployment_started.text.erb
@@ -1,0 +1,1 @@
+Hey @<%= @account.user_name %>. I've started a deployment of <%= @auto_deployment.environment.repository %>@<%= @auto_deployment.sha %> to <%= @auto_deployment.environment %> for you.

--- a/spec/features/auto_deploy_spec.rb
+++ b/spec/features/auto_deploy_spec.rb
@@ -3,9 +3,11 @@ require 'rails_helper'
 RSpec.feature 'Auto Deployment' do
   fixtures :all
   let(:github) { instance_double(GitHub::Client) }
+  let(:slack) { instance_double(Slack::Client) }
 
   before do
     allow(SlashDeploy.service).to receive(:github).and_return(github)
+    allow(SlashDeploy.service).to receive(:slack).and_return(slack)
   end
 
   scenario 'receiving a `push` event from GitHub when the repo is not enabled for auto deployments' do
@@ -31,6 +33,14 @@ RSpec.feature 'Auto Deployment' do
         environment: 'production'
       )
 
+    expect(slack).to receive(:direct_message).with \
+      slack_accounts(:david),
+      Slack::Message.new(text: "Hey @david. I'll start a deployment of baxterthehacker/public-repo@0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c to production for you once commit statuses are passing.")
+
+    expect(slack).to receive(:direct_message).with \
+      slack_accounts(:david),
+      Slack::Message.new(text: "Hey @david. I've started a deployment of baxterthehacker/public-repo@0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c to production for you.")
+
     push_event 'secret', sender: { id: github_accounts(:david).id }
   end
 
@@ -39,6 +49,14 @@ RSpec.feature 'Auto Deployment' do
     environment = repo.environment('production')
     environment.configure_auto_deploy('refs/heads/master')
     environment.lock! users(:david)
+
+    expect(slack).to receive(:direct_message).with \
+      slack_accounts(:david),
+      Slack::Message.new(text: "Hey @david. I'll start a deployment of baxterthehacker/public-repo@0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c to production for you once commit statuses are passing.")
+
+    expect(slack).to receive(:direct_message).with \
+      slack_accounts(:david),
+      Slack::Message.new(text: 'Hey @david. I was going to start a deployment of baxterthehacker/public-repo@0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c to production for you, but production is locked.')
 
     push_event 'secret', sender: { id: github_accounts(:david).id }
   end
@@ -55,6 +73,17 @@ RSpec.feature 'Auto Deployment' do
         ref: '0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c',
         environment: 'production'
       )
+
+    # TODO: These messages should make it clear to this user that we're
+    # deploying on their behalf because we don't know who the pusher is and
+    # this user is configured as the fallback deployer.
+    expect(slack).to receive(:direct_message).with \
+      slack_accounts(:steve),
+      Slack::Message.new(text: "Hey @steve. I'll start a deployment of baxterthehacker/public-repo@0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c to production for you once commit statuses are passing.")
+
+    expect(slack).to receive(:direct_message).with \
+      slack_accounts(:steve),
+      Slack::Message.new(text: "Hey @steve. I've started a deployment of baxterthehacker/public-repo@0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c to production for you.")
 
     push_event 'secret', sender: { id: 1234567 }
   end
@@ -74,6 +103,10 @@ RSpec.feature 'Auto Deployment' do
     environment.required_contexts = ['ci/circleci', 'security/brakeman']
     environment.configure_auto_deploy('refs/heads/master')
 
+    expect(slack).to receive(:direct_message).with \
+      slack_accounts(:david),
+      Slack::Message.new(text: "Hey @david. I'll start a deployment of baxterthehacker/public-repo@0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c to production for you once commit statuses are passing.")
+
     push_event 'secret', sender: { id: github_accounts(:david).id }
     status_event 'secret', context: 'ci/circleci', state: 'pending'
     status_event 'secret', context: 'ci/circleci', state: 'success'
@@ -86,6 +119,10 @@ RSpec.feature 'Auto Deployment' do
         environment: 'production'
       )
 
+    expect(slack).to receive(:direct_message).with \
+      slack_accounts(:david),
+      Slack::Message.new(text: "Hey @david. I've started a deployment of baxterthehacker/public-repo@0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c to production for you.")
+
     status_event 'secret', context: 'security/brakeman', state: 'success'
   end
 
@@ -96,9 +133,19 @@ RSpec.feature 'Auto Deployment' do
     environment.configure_auto_deploy('refs/heads/master')
 
     expect(github).to_not receive(:create_deployment)
+
+    expect(slack).to receive(:direct_message).with \
+      slack_accounts(:david),
+      Slack::Message.new(text: "Hey @david. I'll start a deployment of baxterthehacker/public-repo@0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c to production for you once commit statuses are passing.")
+
     push_event 'secret', sender: { id: github_accounts(:david).id }
     status_event 'secret', context: 'ci/circleci', state: 'pending'
+
+    expect(slack).to receive(:direct_message).with \
+      slack_accounts(:david),
+      Slack::Message.new(text: 'Hey @david. I was going to start a deployment of baxterthehacker/public-repo@0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c to production for you, but *ci/circleci* failed.')
     status_event 'secret', context: 'ci/circleci', state: 'failure'
+
     status_event 'secret', context: 'security/brakeman', state: 'success'
   end
 
@@ -108,8 +155,16 @@ RSpec.feature 'Auto Deployment' do
     environment.required_contexts = ['ci/circleci', 'security/brakeman']
     environment.configure_auto_deploy('refs/heads/master')
 
+    expect(slack).to receive(:direct_message).with \
+      slack_accounts(:david),
+      Slack::Message.new(text: "Hey @david. I'll start a deployment of baxterthehacker/public-repo@0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c to production for you once commit statuses are passing.")
     push_event 'secret', sender: { id: github_accounts(:david).id }
+
     status_event 'secret', context: 'ci/circleci', state: 'success'
+
+    expect(slack).to receive(:direct_message).with \
+      slack_accounts(:david),
+      Slack::Message.new(text: "Hey @david. I'll start a deployment of baxterthehacker/public-repo@ac5b9fd6a09a983a3091d4e8292dc32c to production for you once commit statuses are passing.")
     # Push event for new commit (but same ref).
     push_event 'secret', head_commit: {
       id: 'ac5b9fd6a09a983a3091d4e8292dc32c'


### PR DESCRIPTION
When a user pushes a commit to a branch that's configured to deploy automatically to an environment, SlashDeploy will send the user a DM to let them know:

![](https://s3.amazonaws.com/ejholmes.github.com/kHTay.png)

If the environment is configured to wait for some commit status checks to pass, then it'll let the user know when those checks are passing, and the GitHub deployment is created:

![](https://s3.amazonaws.com/ejholmes.github.com/FibMh.png)

This is pretty rough right now, and there's a couple of TODOs to take care of before this should be merged.

**TODO**

* [x] Using `I18n.t` feels bad. I'd rather use the same system we use in `app/commands` to render slack messages. Should have something that can build named slack messages, and then be able to re-use that.
* [x] Handle cases where a required commit status enters a failed state. We should just pro-actively mark the AutoDeployment as failed when this happens, and message the user.
* [ ] When an AutoDeployment is started as the fallback user, we should let that user know, so they can bug the pusher to use `/deploy`!