### PR TITLE
Remove global default environment

### DIFF
--- a/app/commands/deploy_command.rb
+++ b/app/commands/deploy_command.rb
@@ -3,7 +3,10 @@ class DeployCommand < BaseCommand
   def run
     transaction do
       repo = Repository.with_name(params['repository'])
-      env  = repo.environment(params['environment'])
+      return Slash.reply(ValidationErrorMessage.build(record: repo)) if repo.invalid?
+
+      env = repo.environment(params['environment'])
+      return Slash.reply(ValidationErrorMessage.build(record: env)) if env.invalid?
 
       begin
         resp = slashdeploy.create_deployment(

--- a/app/messages/validation_error_message.rb
+++ b/app/messages/validation_error_message.rb
@@ -1,0 +1,9 @@
+class ValidationErrorMessage < SlackMessage
+  values do
+    attribute :record, Object
+  end
+
+  def to_message
+    Slack::Message.new text: text
+  end
+end

--- a/app/messages/validation_error_message.rb
+++ b/app/messages/validation_error_message.rb
@@ -4,6 +4,11 @@ class ValidationErrorMessage < SlackMessage
   end
 
   def to_message
-    Slack::Message.new text: text
+    fields = record.errors.map do |attribute, error|
+      Slack::Attachment::Field.new title: "#{record.class.name.downcase} #{attribute}", value: error
+    end
+    Slack::Message.new text: text, attachments: [
+      Slack::Attachment.new(fields: fields, color: '#f00')
+    ]
   end
 end

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -8,6 +8,8 @@ class Environment < ActiveRecord::Base
   # Validate that an alias doesn't match a different environment.
   validates_with UniqueEnvironment
 
+  validates :name, presence: true
+
   # Scopes environments to find those that either have the given name, or are
   # aliased.
   scope :named, -> (value) do
@@ -25,7 +27,7 @@ class Environment < ActiveRecord::Base
 
   # Finds the environment with the given name, creating it if necessary.
   def self.with_name(name)
-    named(name).first || create!(name: name)
+    named(name).first || create(name: name)
   end
 
   # Marks this environment as locked with the given message.

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -9,29 +9,25 @@ class Repository < ActiveRecord::Base
 
   # Finds the repository with the given name, creating it if necessary.
   def self.with_name(name)
-    find_or_create_by!(name: name)
+    find_or_create_by(name: name)
   end
 
   # Finds the associated environment with the given name, creating it if
-  # necessary. If name is nil, returns the default environment.
+  # necessary. If name is nil, returns the default environment, if the
+  # repository has a default environment set.
   def environment(name = nil)
     environments.with_name(name || default_environment)
   end
 
   # The default environment to deploy to when one is not specified.
   def default_environment
-    super.presence || self.class.default_environment
+    super.presence
   end
 
   # Returns the environment that's configured to auto deploy this ref.
   # Returns nil if there is no environment configured for this branch.
   def auto_deploy_environment_for_ref(ref)
     environments.find { |env| env.auto_deploy?(ref) }
-  end
-
-  # The name of the default environment for a repository.
-  def self.default_environment
-    Rails.configuration.x.default_environment
   end
 
   def to_s

--- a/app/views/messages/validation_error.text.erb
+++ b/app/views/messages/validation_error.text.erb
@@ -1,0 +1,3 @@
+Invalid <%= @record.class.name.downcase %>: <% @record.errors.each do |attribute, error| %>
+* <%= attribute %>: <%= error %>
+<% end %>

--- a/app/views/messages/validation_error.text.erb
+++ b/app/views/messages/validation_error.text.erb
@@ -1,3 +1,1 @@
-Invalid <%= @record.class.name.downcase %>: <% @record.errors.each do |attribute, error| %>
-* <%= attribute %>: <%= error %>
-<% end %>
+Oops! We had a problem running that command for you.

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,7 +50,6 @@ module SlashDeploy
     #
     #   slack
     config.x.slack_client = ENV['SLACK_CLIENT']
-    config.x.default_environment = 'production'
     config.x.default_ref = 'master'
     config.x.feedback_email = 'hi@slashdeploy.io'
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,7 +26,7 @@ en:
         repository:
           attributes:
             name:
-              invalid_repository: 'is not a valid GitHub repository'
+              invalid_repository: "not a valid GitHub repository"
         environment:
           attributes:
             aliases:

--- a/spec/features/commands_spec.rb
+++ b/spec/features/commands_spec.rb
@@ -194,14 +194,28 @@ RSpec.feature 'Slash Commands' do
     expect do
       command '/deploy acme-inc/$api@master to production', as: slack_accounts(:david)
     end.to_not change { deployment_requests }
-    expect(command_response.message).to eq Slack::Message.new(text: "Invalid repository: \n* name: not a valid GitHub repository")
+    expect(command_response.message).to eq Slack::Message.new(
+      text: 'Oops! We had a problem running that command for you.',
+      attachments: [
+        Slack::Attachment.new(color: '#f00', fields: [
+          Slack::Attachment::Field.new(title: 'repository name', value: 'not a valid GitHub repository')
+        ])
+      ]
+    )
   end
 
   scenario 'trying to /deploy with no environment, when the repository does not have a default' do
     expect do
       command '/deploy acme-inc/api@master', as: slack_accounts(:david)
     end.to_not change { deployment_requests }
-    expect(command_response.message).to eq Slack::Message.new(text: "Invalid environment: \n* name: can't be blank")
+    expect(command_response.message).to eq Slack::Message.new(
+      text: 'Oops! We had a problem running that command for you.',
+      attachments: [
+        Slack::Attachment.new(color: '#f00', fields: [
+          Slack::Attachment::Field.new(title: 'environment name', value: "can't be blank")
+        ])
+      ]
+    )
   end
 
   scenario 'trying to /deploy an environment that is configured to auto deploy' do

--- a/spec/features/commands_spec.rb
+++ b/spec/features/commands_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature 'Slash Commands' do
   end
 
   scenario 'performing a simple deployment' do
-    command '/deploy  acme-inc/api', as: slack_accounts(:david)
+    command '/deploy  acme-inc/api to production', as: slack_accounts(:david)
     expect(deployment_requests).to eq [
       [users(:david), DeploymentRequest.new(repository: 'acme-inc/api', ref: 'master', environment: 'production')]
     ]
@@ -52,7 +52,7 @@ RSpec.feature 'Slash Commands' do
     # David commits something new
     HEAD('acme-inc/api', 'master', 'f5c0df18526b90b9698816ee4b6606e0')
 
-    command '/deploy acme-inc/api', as: slack_accounts(:david)
+    command '/deploy acme-inc/api to production', as: slack_accounts(:david)
     expect(command_response.message).to eq Slack::Message.new(text: 'Created deployment request for <https://github.com/acme-inc/api|acme-inc/api>@<https://github.com/acme-inc/api/commits/f5c0df18526b90b9698816ee4b6606e0|master> to *production* (<https://github.com/acme-inc/api/compare/ad80a1b...f5c0df1|diff>)')
   end
 
@@ -76,14 +76,14 @@ RSpec.feature 'Slash Commands' do
   end
 
   scenario 'performing a deployment using only the repo name' do
-    command '/deploy api@topic', as: slack_accounts(:david)
+    command '/deploy api@topic to production', as: slack_accounts(:david)
     expect(deployment_requests).to eq [
       [users(:david), DeploymentRequest.new(repository: 'acme-inc/api', ref: 'topic', environment: 'production')]
     ]
   end
 
   scenario 'performing a deployment of a topic branch' do
-    command '/deploy acme-inc/api@topic', as: slack_accounts(:david)
+    command '/deploy acme-inc/api@topic to production', as: slack_accounts(:david)
     expect(deployment_requests).to eq [
       [users(:david), DeploymentRequest.new(repository: 'acme-inc/api', ref: 'topic', environment: 'production')]
     ]
@@ -91,27 +91,27 @@ RSpec.feature 'Slash Commands' do
 
   scenario 'performing a deployment of a branch that has failing commit status contexts' do
     expect do
-      command '/deploy acme-inc/api@failing', as: slack_accounts(:david)
+      command '/deploy acme-inc/api@failing to production', as: slack_accounts(:david)
     end.to_not change { deployment_requests }
 
     expect(command_response.message).to eq Slack::Message.new(text: <<-TEXT.strip_heredoc.strip)
     The following commit status checks failed:
     * ci
-    You can ignore commit status checks by using `/deploy acme-inc/api@failing!`
+    You can ignore commit status checks by using `/deploy acme-inc/api@failing to production!`
     TEXT
 
     expect do
-      command '/deploy acme-inc/api@failing!', as: slack_accounts(:david)
+      command '/deploy acme-inc/api@failing to production!', as: slack_accounts(:david)
     end.to change { deployment_requests.count }.by(1)
   end
 
   scenario 'attempting to deploy a repo I do not have access to' do
-    command '/deploy acme-inc/api', as: slack_accounts(:bob)
+    command '/deploy acme-inc/api to production', as: slack_accounts(:bob)
     expect(command_response.message).to eq Slack::Message.new(text: "Sorry, but it looks like you don't have access to acme-inc/api")
   end
 
   scenario 'attempting to deploy a ref that does not exist on github' do
-    command '/deploy acme-inc/api@non-existent-branch', as: slack_accounts(:david)
+    command '/deploy acme-inc/api@non-existent-branch to production', as: slack_accounts(:david)
     expect(command_response.message).to eq Slack::Message.new(text: 'The ref `non-existent-branch` was not found in acme-inc/api')
   end
 
@@ -190,8 +190,23 @@ RSpec.feature 'Slash Commands' do
     TEXT
   end
 
+  scenario 'trying to /deploy to an invalid repoisotory' do
+    expect do
+      command '/deploy acme-inc/$api@master to production', as: slack_accounts(:david)
+    end.to_not change { deployment_requests }
+    expect(command_response.message).to eq Slack::Message.new(text: "Invalid repository: \n* name: not a valid GitHub repository")
+  end
+
+  scenario 'trying to /deploy with no environment, when the repository does not have a default' do
+    expect do
+      command '/deploy acme-inc/api@master', as: slack_accounts(:david)
+    end.to_not change { deployment_requests }
+    expect(command_response.message).to eq Slack::Message.new(text: "Invalid environment: \n* name: can't be blank")
+  end
+
   scenario 'trying to /deploy an environment that is configured to auto deploy' do
     repo = Repository.with_name('acme-inc/api')
+    repo.update_attributes! default_environment: 'production'
     environment = repo.environment('production')
     environment.configure_auto_deploy('refs/heads/master')
 

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Repository, type: :model do
     it 'gets validated as a GitHub repository name' do
       repo = Repository.new(name: 'foo')
       expect(repo).to be_invalid
-      expect(repo.errors[:name]).to eq ['is not a valid GitHub repository']
+      expect(repo.errors[:name]).to eq ['not a valid GitHub repository']
     end
   end
 
@@ -22,6 +22,7 @@ RSpec.describe Repository, type: :model do
     context 'when not given a name' do
       it 'returns the default environment' do
         repo = Repository.with_name('acme-inc/api')
+        repo.default_environment = 'production'
         environment = repo.environment
         expect(environment).to_not be_nil
         expect(environment.name).to eq 'production'
@@ -38,12 +39,12 @@ RSpec.describe Repository, type: :model do
     end
 
     context 'when the repository does not have a default environment' do
-      it 'returns production' do
+      it 'returns nil' do
         repo = Repository.new(default_environment: '')
-        expect(repo.default_environment).to eq 'production'
+        expect(repo.default_environment).to be_nil
 
         repo = Repository.new
-        expect(repo.default_environment).to eq 'production'
+        expect(repo.default_environment).to be_nil
       end
     end
   end


### PR DESCRIPTION
Fixes https://github.com/ejholmes/slashdeploy/issues/39

This removes the global default `production` environment, which was a dangerous default. Repos can still configure a default, if they want to.