### PR TITLE
Improve the behavior of "active" auto deployments.

### DIFF
--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -45,11 +45,6 @@ class Environment < ActiveRecord::Base
     active_lock.present?
   end
 
-  # Returns the currently active auto deployment, if there is one.
-  def active_auto_deployment
-    auto_deployments.active.first
-  end
-
   # Override the aliases setter to filter out aliases that match the name of
   # the environment.
   def aliases=(aliases)

--- a/db/migrate/20160815212720_drop_unique_environment_index.rb
+++ b/db/migrate/20160815212720_drop_unique_environment_index.rb
@@ -1,0 +1,9 @@
+class DropUniqueEnvironmentIndex < ActiveRecord::Migration
+  def up
+    execute 'DROP INDEX unique_auto_deployment_per_environment'
+  end
+  
+  def down
+    add_index :auto_deployments, [:environment_id], name: 'unique_auto_deployment_per_environment', unique: true, where: 'active'
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -507,13 +507,6 @@ CREATE UNIQUE INDEX locked_environment ON locks USING btree (environment_id) WHE
 
 
 --
--- Name: unique_auto_deployment_per_environment; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE UNIQUE INDEX unique_auto_deployment_per_environment ON auto_deployments USING btree (environment_id) WHERE active;
-
-
---
 -- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -627,4 +620,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160609042717');
 INSERT INTO schema_migrations (version) VALUES ('20160725205816');
 
 INSERT INTO schema_migrations (version) VALUES ('20160727164721');
+
+INSERT INTO schema_migrations (version) VALUES ('20160815212720');
 

--- a/lib/slashdeploy/service.rb
+++ b/lib/slashdeploy/service.rb
@@ -29,18 +29,6 @@ module SlashDeploy
     #
     # Returns an AutoDeployment.
     def create_auto_deployment(environment, sha, user)
-      existing = environment.active_auto_deployment
-      if existing
-        # This can happen if the user triggers the webhook manually.
-        return existing if existing.sha == sha
-
-        # If this environment has an existing active auto deployment, we'll
-        # cancel it before starting this auto deployment. We do this to prevent
-        # race conditions where commit status events for an older auto deployment
-        # could come in late.
-        existing.cancel!
-      end
-
       auto_deployment = environment.auto_deployments.create! user: user, sha: sha
       if auto_deployment.ready?
         auto_deploy auto_deployment


### PR DESCRIPTION
Fixes https://github.com/ejholmes/slashdeploy/issues/66

This will allow for multiple "pending" auto deployments. If an auto deployment gets deployed, any pending auto deployments older than the one that went out will be canceled to avoid deploying an older a commit that may have been slower to pass CI.