### PR TITLE
Allow a single ref to be auto deployed to multiple environments

### DIFF
--- a/app/github/status_event.rb
+++ b/app/github/status_event.rb
@@ -2,16 +2,18 @@
 class StatusEvent < GitHubEventHandler
   def run
     transaction do
-      return unless auto_deployment
-      auto_deployment.context_state event['context'], event['state']
-      logger.info "auto_deployment=#{auto_deployment.id} ready=#{auto_deployment.ready?} context=#{event['context']} state=#{event['state']} sha=#{event['sha']}"
-      slashdeploy.auto_deploy auto_deployment if auto_deployment.ready?
+      return unless auto_deployments
+      auto_deployments.each do |auto_deployment|
+        auto_deployment.context_state event['context'], event['state']
+        logger.info "auto_deployment=#{auto_deployment.id} ready=#{auto_deployment.ready?} context=#{event['context']} state=#{event['state']} sha=#{event['sha']}"
+        slashdeploy.auto_deploy auto_deployment if auto_deployment.ready?
+      end
     end
   end
 
   private
 
-  def auto_deployment
-    @auto_deployment ||= AutoDeployment.lock.active.find_by(sha: event['sha'])
+  def auto_deployments
+    @auto_deployments ||= AutoDeployment.lock.active.where(sha: event['sha'])
   end
 end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -26,8 +26,8 @@ class Repository < ActiveRecord::Base
 
   # Returns the environment that's configured to auto deploy this ref.
   # Returns nil if there is no environment configured for this branch.
-  def auto_deploy_environment_for_ref(ref)
-    environments.find { |env| env.auto_deploy?(ref) }
+  def auto_deploy_environments_for_ref(ref)
+    environments.select { |env| env.auto_deploy?(ref) }
   end
 
   # Returns the organization portion of the repository name.


### PR DESCRIPTION
In some cases, it's desirable to be able to automatically deploy the same ref (e.g. `master`) to multiple environments (e.g. `production` and `staging` to ensure that staging always remains up to date)